### PR TITLE
Allow id token hint param

### DIFF
--- a/lib/extensions/discovery.rb
+++ b/lib/extensions/discovery.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Extensions
+  module Discovery
+    Module.new do
+      # Monkey patch allow HTTP instead of forcing HTTPS for discovery.
+
+      attr_reader :scheme
+
+      def initialize(uri)
+        @scheme = uri.scheme
+        super
+      end
+
+      def endpoint
+        URI::Generic.build(scheme: scheme, host: host, port: port, path: path)
+      rescue URI::Error => e
+        raise SWD::Exception.new(e.message)
+      end
+
+      prepend_features(::OpenIDConnect::Discovery::Provider::Config::Resource)
+    end
+  end
+end

--- a/lib/extensions/discovery.rb
+++ b/lib/extensions/discovery.rb
@@ -15,7 +15,7 @@ module Extensions
       def endpoint
         URI::Generic.build(scheme: scheme, host: host, port: port, path: path)
       rescue URI::Error => e
-        raise SWD::Exception.new(e.message)
+        raise SWD::Exception, e.message
       end
 
       prepend_features(::OpenIDConnect::Discovery::Provider::Config::Resource)

--- a/lib/omniauth/strategies/base_strategy.rb
+++ b/lib/omniauth/strategies/base_strategy.rb
@@ -42,7 +42,7 @@ module OmniAuth
         query = {
           post_logout_redirect_uri: options.post_logout_redirect_uri
         }
-        query.merge({ id_token_hint: params["id_token_hint"] }) if params["id_token_hint"]
+        query = query.merge({ id_token_hint: params["id_token_hint"] }) if params["id_token_hint"]
 
         URI.encode_www_form(query)
       end

--- a/lib/omniauth/strategies/base_strategy.rb
+++ b/lib/omniauth/strategies/base_strategy.rb
@@ -6,8 +6,35 @@ require_relative "../../extensions/discovery"
 module OmniAuth
   module Strategies
     class BaseStrategy < OmniAuth::Strategies::OpenIDConnect
+      def public_key
+        @public_key ||= if options.discovery
+                          config.jwks
+                        elsif key_or_secret
+                          key_or_secret
+                        elsif client_options.jwks_uri
+                          fetch_key
+                        end
+      end
 
       private
+
+      def fetch_key
+        @fetch_key ||= parse_jwk_key(::OpenIDConnect.http_client.get_content(client_options.jwks_uri))
+      end
+
+      def key_or_secret
+        @key_or_secret ||=
+          case options.client_signing_alg&.to_sym
+          when :HS256, :HS384, :HS512
+            client_options.secret
+          when :RS256, :RS384, :RS512
+            if options.client_jwk_signing_key
+              parse_jwk_key(options.client_jwk_signing_key)
+            elsif options.client_x509_signing_key
+              parse_x509_key(options.client_x509_signing_key)
+            end
+          end
+      end
 
       def encoded_post_logout_redirect_uri
         return unless options.post_logout_redirect_uri

--- a/lib/omniauth/strategies/base_strategy.rb
+++ b/lib/omniauth/strategies/base_strategy.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "omniauth_openid_connect"
+require_relative "../../extensions/discovery"
+
+module OmniAuth
+  module Strategies
+    class BaseStrategy < OmniAuth::Strategies::OpenIDConnect
+
+      private
+
+      def encoded_post_logout_redirect_uri
+        return unless options.post_logout_redirect_uri
+
+        query = {
+          post_logout_redirect_uri: options.post_logout_redirect_uri
+        }
+        query.merge({ id_token_hint: params["id_token_hint"] }) if params["id_token_hint"]
+
+        URI.encode_www_form(query)
+      end
+    end
+  end
+end

--- a/lib/omniauth/strategies/base_strategy.rb
+++ b/lib/omniauth/strategies/base_strategy.rb
@@ -16,7 +16,7 @@ module OmniAuth
                         end
       end
 
-      private
+    private
 
       def fetch_key
         @fetch_key ||= parse_jwk_key(::OpenIDConnect.http_client.get_content(client_options.jwks_uri))
@@ -28,11 +28,7 @@ module OmniAuth
           when :HS256, :HS384, :HS512
             client_options.secret
           when :RS256, :RS384, :RS512
-            if options.client_jwk_signing_key
-              parse_jwk_key(options.client_jwk_signing_key)
-            elsif options.client_x509_signing_key
-              parse_x509_key(options.client_x509_signing_key)
-            end
+            parse_key
           end
       end
 
@@ -40,11 +36,19 @@ module OmniAuth
         return unless options.post_logout_redirect_uri
 
         query = {
-          post_logout_redirect_uri: options.post_logout_redirect_uri
+          post_logout_redirect_uri: options.post_logout_redirect_uri,
         }
         query = query.merge({ id_token_hint: params["id_token_hint"] }) if params["id_token_hint"]
 
         URI.encode_www_form(query)
+      end
+
+      def parse_key
+        if options.client_jwk_signing_key
+          parse_jwk_key(options.client_jwk_signing_key)
+        elsif options.client_x509_signing_key
+          parse_x509_key(options.client_x509_signing_key)
+        end
       end
     end
   end

--- a/lib/omniauth/strategies/nitro_id.rb
+++ b/lib/omniauth/strategies/nitro_id.rb
@@ -1,18 +1,14 @@
 # frozen_string_literal: true
 
-require "omniauth_openid_connect"
+require_relative "base_strategy"
 
 module OmniAuth
   module Strategies
-    class NitroId < OmniAuth::Strategies::OpenIDConnect
-      DEFAULT_STRATEGY_NAME = "nitro_id"
-      DEFAULT_ISSUER = "https://id.powerhrg.com/"
-      DEFAULT_HOST = "id.powerhrg.com"
-
-      option :name, DEFAULT_STRATEGY_NAME
+    class NitroId < BaseStrategy
+      option :name, "nitro_id"
       option :discovery, true
-      option :issuer, DEFAULT_ISSUER
-      option :client_options, host: DEFAULT_HOST
+      option :issuer, "https://id.powerhrg.com/"
+      option :client_options, host: "id.powerhrg.com"
     end
   end
 end

--- a/lib/omniauth/strategies/tempo_id.rb
+++ b/lib/omniauth/strategies/tempo_id.rb
@@ -1,18 +1,14 @@
 # frozen_string_literal: true
 
-require "omniauth_openid_connect"
+require_relative "base_strategy"
 
 module OmniAuth
   module Strategies
-    class TempoId < OmniAuth::Strategies::OpenIDConnect
-      DEFAULT_STRATEGY_NAME = "tempo_id"
-      DEFAULT_ISSUER = "https://id.streamfinancial.io/"
-      DEFAULT_HOST = "id.streamfinancial.io"
-
-      option :name, DEFAULT_STRATEGY_NAME
+    class TempoId < BaseStrategy
+      option :name, "tempo_id"
       option :discovery, true
-      option :issuer, DEFAULT_ISSUER
-      option :client_options, host: DEFAULT_HOST
+      option :issuer, "https://id.streamfinancial.io/"
+      option :client_options, host: "id.streamfinancial.io"
     end
   end
 end


### PR DESCRIPTION
- Can now accept `id_token_hint` param for the `end_session_endpoint`
- Discovery endpoint no longer requires HTTPS. This is helpful for local development.