### PR TITLE
Add omniauth-rails_csrf_protection dependency

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1] - 2023-03-06
+
+### Added
+
+* Add `omniauth-rails_csrf_protection` dependency. PR [#12](https://github.com/powerhome/omniauth-nitro-id/pull/12)
+
 ## [1.1.0] - 2022-12-14
 
 ### Added
@@ -19,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Initial release
 
-[Unreleased]: https://github.com/powerhome/omniauth-nitro-id/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/powerhome/omniauth-nitro-id/compare/v1.1.1...HEAD
+[1.1.1]: https://github.com/powerhome/omniauth-nitro-id/releases/tag/v1.1.1
 [1.1.0]: https://github.com/powerhome/omniauth-nitro-id/releases/tag/v1.1.0
 [1.0.0]: https://github.com/powerhome/omniauth-nitro-id/releases/tag/v1.0.0

--- a/lib/omniauth/nitro_id/version.rb
+++ b/lib/omniauth/nitro_id/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAuth
   module NitroId
-    VERSION = "1.1.0"
+    VERSION = "1.1.1"
   end
 end

--- a/omniauth-nitro-id.gemspec
+++ b/omniauth-nitro-id.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "omniauth_openid_connect", "~> 0.4.0"
+  spec.add_dependency "omniauth-rails_csrf_protection", "1.0.1"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "guard-rspec"


### PR DESCRIPTION
We shouldn't be using GET requests for OAuth requests. This prevents that and adds a token verifier.