### PR TITLE
[SHD-358] Logout token decode cleanup

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,6 @@ PATH
   remote: .
   specs:
     omniauth-nitro-id (1.2.0)
-      faraday (= 2.7.10)
-      jwt (= 2.7.0)
       omniauth-rails_csrf_protection (= 1.0.1)
       omniauth_openid_connect (~> 0.4.0)
 
@@ -76,7 +74,6 @@ GEM
       bindata
       faraday (~> 2.0)
       faraday-follow_redirects
-    jwt (2.7.0)
     license_finder (7.1.0)
       bundler
       rubyzip (>= 1, < 3)
@@ -98,6 +95,7 @@ GEM
       net-smtp
     method_source (1.0.0)
     mini_mime (1.1.2)
+    mini_portile2 (2.8.4)
     minitest (5.18.1)
     nenv (0.3.0)
     net-imap (0.3.6)
@@ -109,9 +107,8 @@ GEM
       timeout
     net-smtp (0.3.3)
       net-protocol
-    nokogiri (1.15.3-arm64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.15.3-x86_64-linux)
+    nokogiri (1.15.3)
+      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)
@@ -243,6 +240,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  ruby
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/omniauth/strategies/base_strategy.rb
+++ b/lib/omniauth/strategies/base_strategy.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "jwt"
-
 require "omniauth_openid_connect"
 require_relative "../../extensions/discovery"
 
@@ -20,16 +18,15 @@ module OmniAuth
 
       def self.decode_logout_token(token)
         jwks = fetch_jwks
-        jwks.filter! { |key| key[:use] == "sig" }
-        algorithms = jwks.filter_map { |key| key[:alg] }.uniq
-        JWT.decode(token, nil, true, algorithms: algorithms, jwks: jwks)
+        JSON::JWT.decode(token, jwks)
       end
 
       def self.fetch_jwks
-        conn = Faraday.new(url: default_options[:issuer]) { |faraday| faraday.response :raise_error }
-        response = conn.get(".well-known/jwks.json")
-        jwks = JSON.parse(response.body)
-        JWT::JWK::Set.new(jwks)
+        key = ::OpenIDConnect.http_client.get(default_options[:issuer] + ".well-known/jwks.json").body
+        json = key.is_a?(String) ? JSON.parse(key) : key
+        return JSON::JWK::Set.new(json['keys']) if json.key?('keys')
+
+        JSON::JWK.new(json)
       end
 
     private

--- a/lib/omniauth/strategies/base_strategy.rb
+++ b/lib/omniauth/strategies/base_strategy.rb
@@ -22,9 +22,9 @@ module OmniAuth
       end
 
       def self.fetch_jwks
-        key = ::OpenIDConnect.http_client.get(default_options[:issuer] + ".well-known/jwks.json").body
+        key = ::OpenIDConnect.http_client.get("#{default_options[:issuer]}.well-known/jwks.json").body
         json = key.is_a?(String) ? JSON.parse(key) : key
-        return JSON::JWK::Set.new(json['keys']) if json.key?('keys')
+        return JSON::JWK::Set.new(json["keys"]) if json.key?("keys")
 
         JSON::JWK.new(json)
       end

--- a/omniauth-nitro-id.gemspec
+++ b/omniauth-nitro-id.gemspec
@@ -17,8 +17,6 @@ Gem::Specification.new do |spec|
   spec.executables   = []
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday", "2.7.10"
-  spec.add_dependency "jwt", "2.7.0"
   spec.add_dependency "omniauth_openid_connect", "~> 0.4.0"
   spec.add_dependency "omniauth-rails_csrf_protection", "1.0.1"
 


### PR DESCRIPTION
Removes the JWT and Faraday dependencies and instead uses `JSON::JWT`