### PR TITLE
Add introspect_token method

### DIFF
--- a/lib/omniauth/strategies/base_strategy.rb
+++ b/lib/omniauth/strategies/base_strategy.rb
@@ -39,9 +39,7 @@ module OmniAuth
 
         response = ::OpenIDConnect.http_client.post("#{default_options[:issuer]}api/tokens/introspect", **options)
 
-        if response.status.to_i >= 400
-          raise APIError, "#{default_options[:name]} error: #{response.status}"
-        end
+        raise APIError, "#{default_options[:name]} error: #{response.status}" if response.status.to_i >= 400
 
         JSON.parse(response.body)
       end

--- a/lib/omniauth/strategies/base_strategy.rb
+++ b/lib/omniauth/strategies/base_strategy.rb
@@ -6,6 +6,8 @@ require_relative "../../extensions/discovery"
 module OmniAuth
   module Strategies
     class BaseStrategy < OmniAuth::Strategies::OpenIDConnect
+      class APIError < StandardError; end
+
       def public_key
         @public_key ||= if options.discovery
                           config.jwks
@@ -38,7 +40,7 @@ module OmniAuth
         response = ::OpenIDConnect.http_client.post("#{default_options[:issuer]}api/tokens/introspect", **options)
 
         if response.status.to_i >= 400
-          raise HTTPClient::BadResponseError, "#{default_options[:name]} error: #{response.status}"
+          raise APIError, "#{default_options[:name]} error: #{response.status}"
         end
 
         JSON.parse(response.body)

--- a/lib/omniauth/strategies/base_strategy.rb
+++ b/lib/omniauth/strategies/base_strategy.rb
@@ -29,6 +29,21 @@ module OmniAuth
         JSON::JWK.new(json)
       end
 
+      def self.introspect_token(token, api_key)
+        options = {
+          header: { Authorization: api_key },
+          body: { token: token },
+        }
+
+        response = ::OpenIDConnect.http_client.post("#{default_options[:issuer]}api/tokens/introspect", **options)
+
+        if response.status.to_i >= 400
+          raise HTTPClient::BadResponseError, "#{default_options[:name]} error: #{response.status}"
+        end
+
+        JSON.parse(response.body)
+      end
+
     private
 
       def fetch_key


### PR DESCRIPTION
Active

```
irb(main):002:0> OmniAuth::Strategies::NitroId.introspect_token(...)
=> {"active"=>true, "exp"=>1692731908, "sub"=>"employee/70999"}
```

Inactive

```
irb(main):003:0> r = OmniAuth::Strategies::NitroId.introspect_token(...)
=> {"active"=>false}
```

Error

```
irb(main):004:0> r = OmniAuth::Strategies::NitroId.introspect_token(...)
Traceback (most recent call last):
        3: from bin/console:8:in `<main>'
        2: from (irb):4
        1: from /Users/greersa/Workspace/omniauth-nitro-id/lib/omniauth/strategies/base_strategy.rb:41:in `introspect_token'
HTTPClient::BadResponseError (nitro_id error: 401)
```
