### PR TITLE
Display better error message for missing credentials

### DIFF
--- a/lib/omniauth/strategies/base_strategy.rb
+++ b/lib/omniauth/strategies/base_strategy.rb
@@ -7,6 +7,7 @@ module OmniAuth
   module Strategies
     class BaseStrategy < OmniAuth::Strategies::OpenIDConnect
       class APIError < StandardError; end
+      class ClientCredentialsError < StandardError; end
 
       def public_key
         @public_key ||= if options.discovery
@@ -16,6 +17,14 @@ module OmniAuth
                         elsif client_options.jwks_uri
                           fetch_key
                         end
+      end
+
+      def client
+        super
+      rescue AttrRequired::AttrMissing
+        raise ClientCredentialsError.new(
+          "#{options[:name].camelize} client credentials not found. Please check your environment."
+        )
       end
 
       def self.decode_logout_token(token)

--- a/lib/omniauth/strategies/base_strategy.rb
+++ b/lib/omniauth/strategies/base_strategy.rb
@@ -22,9 +22,8 @@ module OmniAuth
       def client
         super
       rescue AttrRequired::AttrMissing
-        raise ClientCredentialsError.new(
-          "#{options[:name].camelize} client credentials not found. Please check your environment."
-        )
+        raise ClientCredentialsError,
+              "#{options[:name].camelize} client credentials not found. Please check your environment."
       end
 
       def self.decode_logout_token(token)


### PR DESCRIPTION
```
irb(main):002:0> OmniAuth::Strategies::NitroId.new({}).client
Traceback (most recent call last):
        5: from bin/console:8:in `<main>'
        4: from (irb):1
        3: from (irb):2:in `rescue in irb_binding'
        2: from /Users/greersa/Workspace/omniauth-nitro-id/lib/omniauth/strategies/base_strategy.rb:22:in `client'
        1: from /Users/greersa/Workspace/omniauth-nitro-id/lib/omniauth/strategies/base_strategy.rb:25:in `rescue in client'
OmniAuth::Strategies::BaseStrategy::ClientCredentialsError (NitroId client credentials not found. Please check your environment.)
```