### PR TITLE
Fix config urls post issuer update

### DIFF
--- a/lib/omniauth/strategies/base_strategy.rb
+++ b/lib/omniauth/strategies/base_strategy.rb
@@ -32,7 +32,7 @@ module OmniAuth
       end
 
       def self.fetch_jwks
-        key = ::OpenIDConnect.http_client.get("#{default_options[:issuer]}.well-known/jwks.json").body
+        key = ::OpenIDConnect.http_client.get("#{default_options[:issuer]}/.well-known/jwks.json").body
         json = key.is_a?(String) ? JSON.parse(key) : key
         return JSON::JWK::Set.new(json["keys"]) if json.key?("keys")
 
@@ -45,7 +45,7 @@ module OmniAuth
           body: { token: token },
         }
 
-        response = ::OpenIDConnect.http_client.post("#{default_options[:issuer]}api/tokens/introspect", **options)
+        response = ::OpenIDConnect.http_client.post("#{default_options[:issuer]}/api/tokens/introspect", **options)
 
         raise APIError, "#{default_options[:name]} error: #{response.status}" if response.status.to_i >= 400
 


### PR DESCRIPTION
Changing the default `issuer` value broke the `.well-known` and token introspection endpoints. This PR corrects those values