### PR TITLE
[SHD-1009] Use dynamic options

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* Use dynamic issuer for JWK discovery and token intropsection
+
+## [1.3.3] - 2024-07-01
+
+### Fixed
+
+* Correct URLs for JWK discovery and token introspection. PR [#43](https://github.com/powerhome/omniauth-nitro-id/pull/43)
+
+## [1.3.2] - 2024-06-30
+
+### Fixed
+
+* Correct default issuer value for nitro-id and tempo-id strategies. PR [#41](https://github.com/powerhome/omniauth-nitro-id/pull/41)
+
 ## [1.3.1] - 2023-09-21
 
 * Display better error message for missing credentials. PR [#27](https://github.com/powerhome/omniauth-nitro-id/pull/27)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -63,7 +63,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Initial release
 
-[Unreleased]: https://github.com/powerhome/omniauth-nitro-id/compare/v1.3.1...HEAD
+[Unreleased]: https://github.com/powerhome/omniauth-nitro-id/compare/v1.3.3...HEAD
+[1.3.3]: https://github.com/powerhome/omniauth-nitro-id/releases/tag/v1.3.3
+[1.3.2]: https://github.com/powerhome/omniauth-nitro-id/releases/tag/v1.3.2
 [1.3.1]: https://github.com/powerhome/omniauth-nitro-id/releases/tag/v1.3.1
 [1.3.0]: https://github.com/powerhome/omniauth-nitro-id/releases/tag/v1.3.0
 [1.2.1]: https://github.com/powerhome/omniauth-nitro-id/releases/tag/v1.2.1

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* Use dynamic issuer for JWK discovery and token intropsection
+* Use dynamic issuer for JWK discovery and token introspection
 
 ## [1.3.3] - 2024-07-01
 

--- a/lib/omniauth/strategies/base_strategy.rb
+++ b/lib/omniauth/strategies/base_strategy.rb
@@ -32,7 +32,7 @@ module OmniAuth
       end
 
       def self.fetch_jwks
-        key = ::OpenIDConnect.http_client.get("#{default_options[:issuer]}/.well-known/jwks.json").body
+        key = ::OpenIDConnect.http_client.get("#{options[:issuer]}/.well-known/jwks.json").body
         json = key.is_a?(String) ? JSON.parse(key) : key
         return JSON::JWK::Set.new(json["keys"]) if json.key?("keys")
 
@@ -45,9 +45,9 @@ module OmniAuth
           body: { token: token },
         }
 
-        response = ::OpenIDConnect.http_client.post("#{default_options[:issuer]}/api/tokens/introspect", **options)
+        response = ::OpenIDConnect.http_client.post("#{options[:issuer]}/api/tokens/introspect", **options)
 
-        raise APIError, "#{default_options[:name]} error: #{response.status}" if response.status.to_i >= 400
+        raise APIError, "#{options[:name]} error: #{response.status}" if response.status.to_i >= 400
 
         JSON.parse(response.body)
       end


### PR DESCRIPTION
Use dynamic issuer for JWK discovery and token introspection.

This is needed for testing integration with NitroID environments outside of production. This is useful when testing feature additions or updates to NitroID's OAuth flows.