### PR TITLE
[SHD-1482] - Remove Token Helper Methods

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -31,13 +31,4 @@ config.omniauth :nitro_id, {
 }
 ```
 
-Decoding NitroID's RSA256-encoded logout token
-```ruby
-token = params[:logout_token]
-# eyJhbGciOiJSUzI1NiIsImtpZCI6InB1YmxpYzpoeWRyYS5vcGVuaWQuaWQtdG9rZW4iLCJ0eXAiOiJK...
-
-OmniAuth::Strategies::NitroId.decode_logout_token(token)
-# [{"aud"=>["196da0d5-adc6-4454-98f2-3cabae04855c"], "events"=>{"http://schemas.openid.net/event/backchannel-logout"=>{}}, "iat"=>1688672696, "iss"=>"https://id.powerhrg.com/" ...
-```
-
 Check out Power's [example Rails app](https://github.com/powerhome/example-rails-app) for details on how to use this gem with Devise.

--- a/lib/omniauth/strategies/base_strategy.rb
+++ b/lib/omniauth/strategies/base_strategy.rb
@@ -26,32 +26,6 @@ module OmniAuth
               "#{options[:name].camelize} client credentials not found. Please check your environment."
       end
 
-      def self.decode_logout_token(token)
-        jwks = fetch_jwks
-        JSON::JWT.decode(token, jwks)
-      end
-
-      def self.fetch_jwks
-        key = ::OpenIDConnect.http_client.get("#{options[:issuer]}/.well-known/jwks.json").body
-        json = key.is_a?(String) ? JSON.parse(key) : key
-        return JSON::JWK::Set.new(json["keys"]) if json.key?("keys")
-
-        JSON::JWK.new(json)
-      end
-
-      def self.introspect_token(token, api_key)
-        options = {
-          header: { Authorization: api_key },
-          body: { token: token },
-        }
-
-        response = ::OpenIDConnect.http_client.post("#{options[:issuer]}/api/tokens/introspect", **options)
-
-        raise APIError, "#{options[:name]} error: #{response.status}" if response.status.to_i >= 400
-
-        JSON.parse(response.body)
-      end
-
     private
 
       def fetch_key


### PR DESCRIPTION
Removes the `decode_token`, `fetch_jwks`, and `introspect_token` helper methods, as they are no longer needed for use, and contained buggy code.